### PR TITLE
Fix Mobile Container Having White Border on Mobile

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,11 @@
+body {
+  background: #1a1a1a;
+  margin: 0;
+  padding: 0;
+}
+
 #root {
-  max-width: 375px;
+  max-width: 390px;
   min-height: 100vh;
   margin: 0 auto;
   background: #000000;
@@ -8,18 +14,12 @@
 }
 
 @media (min-width: 768px) {
-  body {
-    background: #1a1a1a;
-    margin: 0;
-    padding: 0;
-  }
-
   #root {
     box-shadow: 0 0 20px rgba(0, 0, 0, 0.5);
   }
 }
 
-@media (max-width: 374px) {
+@media (max-width: 767px) {
   #root {
     max-width: 100%;
   }


### PR DESCRIPTION
This pull request resolves #9 by adjusting the `index.css` file to remove white border in the mobile container.