### PR TITLE
Change Project to Clone Facebook App

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Instagram App
+# Facebook App
 
-A web-based [Instagram](https://www.instagram.com/) clone built using [React](https://react.dev/).
+A web-based [Facebook](https://www.facebook.com/) clone built using [React](https://react.dev/).
 
 ## License
 

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/react.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Instagram App</title>
+    <title>Facebook App</title>
   </head>
   <body>
     <div id="root"></div>

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "instagram-app",
+  "name": "facebook-app",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
This pull request resolves #12 by changing the project to clone [Facebook](https://www.facebook.com/) app instead.